### PR TITLE
Calculate mobility adjustments weekly instead of daily

### DIFF
--- a/R/util.R
+++ b/R/util.R
@@ -230,11 +230,12 @@ mobility_adjust <- function(t, zeta, mobility_table)
   tmax <- ttbl[imax]
 
   
-  ival <- 
-    ifelse(t > tmax, 
-           imax,
-           which.max(ttbl >= t))
+  # ival <- 
+  #   ifelse(t > tmax, 
+  #          imax,
+  #          which.max(ttbl >= t))
 
+  ival <- which.max(ttbl >= t)     # sentinel value guarantees that there is at least one value.
   mobval <- mobility_table[[2]][ival]
   
   exp(zeta * mobval)  
@@ -271,7 +272,7 @@ local_mobility <- function(locality)
   if(nr == 0) {
     ## No data in the table, so create a dummy table that will produce no 
     ## adjustment.
-    mobility_table <- tibble::tibble(t=c(0,1), mobility=c(0,0))
+    mobility_table <- tibble::tibble(t=c(0,1e6), mobility=c(0,0))
   }
   
   as.list(mobility_table)

--- a/R/util.R
+++ b/R/util.R
@@ -228,16 +228,14 @@ mobility_adjust <- function(t, zeta, mobility_table)
   ttbl <- mobility_table[[1]]
   imax <- which.max(ttbl)
   tmax <- ttbl[imax]
-  tmin <- min(ttbl)
+
   
   ival <- 
     ifelse(t > tmax, 
            imax,
-           1 + round(t) - tmin)
+           which.max(ttbl >= t))
 
-  mobval <- ifelse(ival<1,
-                   0,
-                   mobility_table[[2]][ival])
+  mobval <- mobility_table[[2]][ival]
   
   exp(zeta * mobval)  
 }
@@ -264,18 +262,13 @@ local_mobility <- function(locality)
 {
   mobility_col <- getOption('CovMitigation.mobility_column', default='home')
   mobility_table <- 
-    va_mobility_daily[va_mobility_daily$locality == locality , 
+    va_mobility_weekly[va_mobility_weekly$locality == locality , 
                       c('t', mobility_col)]
   names(mobility_table) <- c('t', 'mobility')
   mobility_table <- mobility_table[!is.na(mobility_table[['mobility']]),]
   
   nr <- nrow(mobility_table)
-  if(nr > 0) {
-    ## Check that there are no gaps in the table.
-    nday <- 1 + max(mobility_table[['t']]) - min(mobility_table[['t']])
-    stopifnot(nr==nday)
-  }
-  else {
+  if(nr == 0) {
     ## No data in the table, so create a dummy table that will produce no 
     ## adjustment.
     mobility_table <- tibble::tibble(t=c(0,1), mobility=c(0,0))

--- a/data-raw/install-mobility-data.R
+++ b/data-raw/install-mobility-data.R
@@ -62,4 +62,18 @@ va_mobility_weekly <-
   ungroup() %>%
   mutate(t = as.numeric(date - as.Date('2020-01-01')))
 
+sentinels <- lapply(unique(va_mobility_weekly$locality), 
+                    function(loc) {
+                      ld <- filter(va_mobility_weekly, locality==loc)
+                      sentinel <- ld[nrow(ld),]
+                      sentinel[1,'t'] <- 1e6
+                      sentinel[1,'date'] <- 1e6 + as.Date('2020-01-01')
+                      sentinel
+                    }) %>%
+  bind_rows()
+
+va_mobility_weekly <- 
+  bind_rows(sentinels, va_mobility_weekly) %>%
+  arrange(locality, t)
+
 usethis::use_data(va_mobility_daily, va_mobility_weekly, overwrite=TRUE)


### PR DESCRIPTION
This dramatically improves performance in the likelihood calculation.
