### PR TITLE
Change mobility indicator to 'work'.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: CovMitigation
 Title: COVID-19 infection model for Virginia
-Version: 3.0.2
+Version: 3.1.0.1000
 Authors@R:
     person(given = "Robert",
            family = "Link",

--- a/R/util.R
+++ b/R/util.R
@@ -256,7 +256,7 @@ mobility_adjust <- function(t, zeta, mobility_table)
 #' @export
 local_mobility <- function(locality, scenario=NULL)
 {
-  mobility_col <- 'home'
+  mobility_col <- 'work'
   if(is.null(scenario)) {
     mobility_base_table <- va_mobility_weekly
   }


### PR DESCRIPTION
The work column is highly correlated with the home column, but it has
less missing data.